### PR TITLE
FIX: #8 prevent AccessDenied Exception when choosing email 2FA type

### DIFF
--- a/src/Controller/TwoFactorController.php
+++ b/src/Controller/TwoFactorController.php
@@ -38,9 +38,9 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 
 final class TwoFactorController extends AbstractController
 {
-    private const AUTH_SECRET_SESSION_KEY = 'googleAuthSecret';
+    private const string AUTH_SECRET_SESSION_KEY = 'googleAuthSecret';
 
-    private const AUTH_EMAIL_SESSION_KEY = 'emailAuthCode';
+    private const string AUTH_EMAIL_SESSION_KEY = 'emailAuthCode';
 
     /**
      * @param UserRepositoryInterface<UserInterface> $repository
@@ -110,8 +110,15 @@ final class TwoFactorController extends AbstractController
             $data = $flow->getData();
             $code = $data['verify_code']['verification_code'] ?? '';
 
+            $sessionKey = '';
+            if ($type === 'google') {
+                $sessionKey = self::AUTH_SECRET_SESSION_KEY;
+            } elseif ($type === 'email') {
+                $sessionKey = self::AUTH_EMAIL_SESSION_KEY;
+            }
+
             /** @var string|null $secret */
-            $secret = $request->getSession()->get(self::AUTH_SECRET_SESSION_KEY);
+            $secret = $request->getSession()->get($sessionKey);
             if ($secret === null) {
                 throw $this->createAccessDeniedException();
             }


### PR DESCRIPTION
**Description**

Issue: #8 

In our `TwoFactorController` we define two session keys:

https://github.com/bitExpert/sylius-2fa/blob/f95e3b2e8f4f690fedaa3748805ec72faad36738/src/Controller/TwoFactorController.php#L41-L43

But we are only using the `googleAuthSecret` so far as you can see here:

https://github.com/bitExpert/sylius-2fa/blob/f95e3b2e8f4f690fedaa3748805ec72faad36738/src/Controller/TwoFactorController.php#L113-L117

This means if we choose the email type in the storefront, it would end in a AccessDenied Exception as `$secret` is `null` when choosing the email 2FA type.
