### PR TITLE
FEAT: #6 Notify email for customer when 2FA is successfully enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ php bin/console doctrine:migrations:migrate
 
 You can run the unit tests with the following command (requires dependency installation):
 
-    ./vendor/bin/phpunit
+```bash
+./vendor/bin/phpunit
+```
 
 ## Contribution
 Feel free to contribute to this module by reporting issues or create some pull requests for improvements.

--- a/config/services/controller.xml
+++ b/config/services/controller.xml
@@ -42,6 +42,7 @@
             <argument type="string"  key="$entity">shop_user</argument>
             <argument type="string"  key="$redirectRoute">bitexpert_sylius_2fa_shop_account_2fa_overview</argument>
             <argument type="string"  key="$template">@BitExpertSyliusTwoFactorAuthPlugin/shop/two_factor_setup.html.twig</argument>
+            <argument type="service" key="$twoFactorEnabledMailer" id="BitExpert\SyliusTwoFactorAuthPlugin\Mailer\SyliusTwoFactorEnabledMailer" />
             <tag name="controller.service_arguments" />
         </service>
     </services>

--- a/config/services/mailer.xml
+++ b/config/services/mailer.xml
@@ -11,5 +11,15 @@
             <argument type="service" id="sylius.context.channel" />
             <argument type="service" id="sylius.context.locale" />
         </service>
+
+        <service id="BitExpert\SyliusTwoFactorAuthPlugin\Mailer\SyliusTwoFactorEnabledMailer"
+                 class="BitExpert\SyliusTwoFactorAuthPlugin\Mailer\SyliusTwoFactorEnabledMailer">
+            <argument type="service" id="mailer" />
+            <argument type="service" id="sylius.context.channel" />
+            <argument type="service" id="sylius.context.locale" />
+            <argument type="service" id="logger" />
+            <argument type="service" id="twig" />
+            <argument type="service" id="translator" />
+        </service>
     </services>
 </container>

--- a/src/Controller/TwoFactorController.php
+++ b/src/Controller/TwoFactorController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace BitExpert\SyliusTwoFactorAuthPlugin\Controller;
 
 use BitExpert\SyliusTwoFactorAuthPlugin\Entity\TwoFactorAuthInterface;
+use BitExpert\SyliusTwoFactorAuthPlugin\Mailer\SyliusTwoFactorEnabledMailer;
 use Endroid\QrCode\Builder\Builder;
 use Endroid\QrCode\Encoding\Encoding;
 use Endroid\QrCode\ErrorCorrectionLevel;
@@ -58,6 +59,7 @@ final class TwoFactorController extends AbstractController
         private readonly string $entity,
         private readonly string $redirectRoute,
         private readonly string $template,
+        private readonly ?SyliusTwoFactorEnabledMailer $twoFactorEnabledMailer = null,
     ) {
     }
 
@@ -128,6 +130,9 @@ final class TwoFactorController extends AbstractController
                 $resource->setGoogleAuthenticatorSecret($secret);
                 if ($this->googleAuthenticator->checkCode($resource, $code)) {
                     $this->repository->add($resource);
+                    if ($resource->getEmail() !== null) {
+                        $this->twoFactorEnabledMailer?->send2FaEnabledMail($resource->getEmail());
+                    }
                     $this->addFlash('success', 'bitexpert_sylius_twofactor.2fa_setup.success');
 
                     return $this->redirectToRoute($this->redirectRoute);
@@ -136,6 +141,9 @@ final class TwoFactorController extends AbstractController
                 $resource->setEmailAuthCode($secret);
                 if ($code === $resource->getEmailAuthCode()) {
                     $this->repository->add($resource);
+                    if ($resource->getEmail() !== null) {
+                        $this->twoFactorEnabledMailer?->send2FaEnabledMail($resource->getEmail());
+                    }
                     $this->addFlash('success', 'bitexpert_sylius_twofactor.2fa_setup.success');
 
                     return $this->redirectToRoute($this->redirectRoute);

--- a/src/Mailer/SyliusTwoFactorEnabledMailer.php
+++ b/src/Mailer/SyliusTwoFactorEnabledMailer.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Sylius 2FA Auth package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace BitExpert\SyliusTwoFactorAuthPlugin\Mailer;
+
+use Psr\Log\LoggerInterface;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Email;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
+
+final readonly class SyliusTwoFactorEnabledMailer
+{
+    public function __construct(
+        private MailerInterface $mailer,
+        private ChannelContextInterface $channelContext,
+        private LocaleContextInterface $localeContext,
+        private LoggerInterface $logger,
+        private Environment $twig,
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    public function send2FaEnabledMail(string $recipientEmail): void
+    {
+        $channel = $this->channelContext->getChannel();
+
+        if (!$channel instanceof ChannelInterface) {
+            $this->logger->info('Cannot send 2FA activation email: channel is not a Sylius ChannelInterface instance.');
+
+            return;
+        }
+
+        $contactEmail = $channel->getContactEmail();
+        if ($contactEmail === null || $contactEmail === '') {
+            $this->logger->info(
+                'Cannot send 2FA activation email: no contact email configured for channel "{channel}".',
+                ['channel' => $channel->getCode()],
+            );
+
+            return;
+        }
+
+        $localeCode = $this->localeContext->getLocaleCode();
+
+        try {
+            $body = $this->twig->render('@BitExpertSyliusTwoFactorAuthPlugin/email/2fa_enabled.html.twig', [
+                'channel' => $channel,
+                'localeCode' => $localeCode,
+            ]);
+
+            $email = (new Email())
+                ->from($contactEmail)
+                ->to($recipientEmail)
+                ->subject($this->translator->trans('bitexpert_sylius_twofactor.2fa_enabled_email.subject', locale: $localeCode))
+                ->html($body);
+
+            $this->mailer->send($email);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Failed to send 2FA activation email to "{recipient}": {error}',
+                ['recipient' => $recipientEmail, 'error' => $e->getMessage()],
+            );
+        }
+    }
+}

--- a/templates/email/2fa_enabled.html.twig
+++ b/templates/email/2fa_enabled.html.twig
@@ -1,0 +1,7 @@
+{% extends '@SyliusCore/Email/layout.html.twig' %}
+
+{% block content %}
+<div style="text-align: center;">
+    {{ 'bitexpert_sylius_twofactor.2fa_enabled_email.message'|trans }}
+</div>
+{% endblock %}

--- a/tests/Unit/Mailer/SyliusTwoFactorEnabledMailerTest.php
+++ b/tests/Unit/Mailer/SyliusTwoFactorEnabledMailerTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/*
+ * This file is part of the Sylius 2FA Auth package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\BitExpert\SyliusTwoFactorAuthPlugin\Unit\Mailer;
+
+use BitExpert\SyliusTwoFactorAuthPlugin\Mailer\SyliusTwoFactorEnabledMailer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Model\ChannelInterface as BaseChannelInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Email;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
+
+final class SyliusTwoFactorEnabledMailerTest extends TestCase
+{
+    /** @var MockObject&MailerInterface */
+    private MailerInterface $mailer;
+
+    /** @var MockObject&ChannelContextInterface */
+    private ChannelContextInterface $channelContext;
+
+    /** @var MockObject&LocaleContextInterface */
+    private LocaleContextInterface $localeContext;
+
+    /** @var MockObject&LoggerInterface */
+    private LoggerInterface $logger;
+
+    /** @var MockObject&Environment */
+    private Environment $twig;
+
+    /** @var MockObject&TranslatorInterface */
+    private TranslatorInterface $translator;
+
+    private SyliusTwoFactorEnabledMailer $syliusTwoFactorEnabledMailer;
+
+    protected function setUp(): void
+    {
+        $this->mailer = $this->createMock(MailerInterface::class);
+        $this->channelContext = $this->createMock(ChannelContextInterface::class);
+        $this->localeContext = $this->createMock(LocaleContextInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->twig = $this->createMock(Environment::class);
+        $this->translator = $this->createMock(TranslatorInterface::class);
+
+        $this->syliusTwoFactorEnabledMailer = new SyliusTwoFactorEnabledMailer(
+            $this->mailer,
+            $this->channelContext,
+            $this->localeContext,
+            $this->logger,
+            $this->twig,
+            $this->translator,
+        );
+    }
+
+    #[Test]
+    public function itLogsAndSkipsWhenChannelIsNotASyliusChannel(): void
+    {
+        $channel = $this->createMock(BaseChannelInterface::class);
+        $this->channelContext->method('getChannel')->willReturn($channel);
+
+        $this->logger->expects($this->once())->method('info');
+        $this->mailer->expects($this->never())->method('send');
+
+        $this->syliusTwoFactorEnabledMailer->send2FaEnabledMail('customer@example.com');
+    }
+
+    #[Test]
+    public function itLogsAndSkipsWhenContactEmailIsNull(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $channel->method('getContactEmail')->willReturn(null);
+        $channel->method('getCode')->willReturn('FASHION_WEB');
+        $this->channelContext->method('getChannel')->willReturn($channel);
+
+        $this->logger->expects($this->once())->method('info');
+        $this->mailer->expects($this->never())->method('send');
+
+        $this->syliusTwoFactorEnabledMailer->send2FaEnabledMail('customer@example.com');
+    }
+
+    #[Test]
+    public function itLogsAndSkipsWhenContactEmailIsEmpty(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $channel->method('getContactEmail')->willReturn('');
+        $channel->method('getCode')->willReturn('FASHION_WEB');
+        $this->channelContext->method('getChannel')->willReturn($channel);
+
+        $this->logger->expects($this->once())->method('info');
+        $this->mailer->expects($this->never())->method('send');
+
+        $this->syliusTwoFactorEnabledMailer->send2FaEnabledMail('customer@example.com');
+    }
+
+    #[Test]
+    public function itSendsEmailWithContactEmailAsFromAndRecipientAsTo(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $channel->method('getContactEmail')->willReturn('shop@example.com');
+        $this->channelContext->method('getChannel')->willReturn($channel);
+        $this->localeContext->method('getLocaleCode')->willReturn('en_US');
+        $this->twig->method('render')->willReturn('2FA activated');
+        $this->translator->method('trans')->willReturn('Two-Factor Authentication Activated');
+
+        $this->mailer->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function (Email $email): bool {
+                $from = $email->getFrom();
+                $this->assertCount(1, $from);
+                $this->assertSame('shop@example.com', $from[0]->getAddress());
+
+                $to = $email->getTo();
+                $this->assertCount(1, $to);
+                $this->assertSame('customer@example.com', $to[0]->getAddress());
+
+                $this->assertSame('Two-Factor Authentication Activated', $email->getSubject());
+
+                return true;
+            }));
+
+        $this->syliusTwoFactorEnabledMailer->send2FaEnabledMail('customer@example.com');
+    }
+
+    #[Test]
+    public function itRendersTemplateWithChannelAndLocale(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $channel->method('getContactEmail')->willReturn('shop@example.com');
+        $this->channelContext->method('getChannel')->willReturn($channel);
+        $this->localeContext->method('getLocaleCode')->willReturn('de_DE');
+        $this->translator->method('trans')->willReturn('Zwei-Faktor-Authentifizierung aktiviert');
+        $this->mailer->method('send');
+
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with(
+                '@BitExpertSyliusTwoFactorAuthPlugin/email/2fa_enabled.html.twig',
+                [
+                    'channel' => $channel,
+                    'localeCode' => 'de_DE',
+                ],
+            )
+            ->willReturn('2FA aktiviert');
+
+        $this->syliusTwoFactorEnabledMailer->send2FaEnabledMail('customer@example.com');
+    }
+
+    #[Test]
+    public function itPassesLocaleToTranslator(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $channel->method('getContactEmail')->willReturn('shop@example.com');
+        $this->channelContext->method('getChannel')->willReturn($channel);
+        $this->localeContext->method('getLocaleCode')->willReturn('de_DE');
+        $this->twig->method('render')->willReturn('2FA aktiviert');
+        $this->mailer->method('send');
+
+        $this->translator->expects($this->once())
+            ->method('trans')
+            ->with('bitexpert_sylius_twofactor.2fa_enabled_email.subject', [], null, 'de_DE')
+            ->willReturn('Zwei-Faktor-Authentifizierung aktiviert');
+
+        $this->syliusTwoFactorEnabledMailer->send2FaEnabledMail('customer@example.com');
+    }
+}

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -54,4 +54,7 @@ bitexpert_sylius_twofactor:
           headline: Geben Sie Ihren Verifizierungscode ein
   email_template:
     subject: Verifizierungscode für E-Mail-Authentifizierung
-    message: Verwenden Sie diesen Code „%authCode%“, um sich bei Sylius anzumelden
+    message: Verwenden Sie diesen Code „%authCode%”, um sich bei Sylius anzumelden
+  2fa_enabled_email:
+    subject: Zwei-Faktor-Authentifizierung aktiviert
+    message: Die Zwei-Faktor-Authentifizierung wurde erfolgreich für Ihr Konto aktiviert.

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -55,3 +55,6 @@ bitexpert_sylius_twofactor:
   email_template:
     subject: Email Auth Code Verification
     message: Use this "%authCode%" code to log into Sylius
+  2fa_enabled_email:
+    subject: Two-Factor Authentication Activated
+    message: Two-factor authentication has been successfully activated for your account.

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -54,3 +54,6 @@ bitexpert_sylius_twofactor:
   email_template:
     subject: Vérification du code d’authentification par e-mail
     message: Utilisez ce code « %authCode% » pour vous connecter à Sylius
+  2fa_enabled_email:
+    subject: Authentification à deux facteurs activée
+    message: L’authentification à deux facteurs a été activée avec succès pour votre compte.


### PR DESCRIPTION
**Description**

Issue: #6

With this feature, shop users will get an e-mail after they successfully enabled, and configured the 2FA in the storefront.