### PR TITLE
chore: add keywords to composer json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,11 @@
             "homepage": "https://www.bitExpert.de"
         }
     ],
+    "keywords": [
+        "sylius",
+        "sylius-plugin",
+        "2fa-auth"
+    ],
     "require": {
         "php": "^8.2",
         "endroid/qr-code-bundle": "^6.0",


### PR DESCRIPTION
**Description**

This PR adds "keywords" to the composer.json file.

This improves the visibility from our package as the keywords can be used for filtering and sorting. For example on packagist:

<img width="326" height="474" alt="image" src="https://github.com/user-attachments/assets/15feab1a-1d48-402c-bd1e-e4bbb05913a7" />

See also: https://getcomposer.org/doc/04-schema.md#keywords